### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,27 +1,27 @@
 # Syntax Coloring Map For MCP23017
 
-MCP23017 KEYWORD1
-MCP23017_Port_t KEYWORD1
-MCP23017_Register_t KEYWORD1
-MCP23017_RegisterGeneric_t KEYWORD1
-MCP23017_Port_t KEYWORD1
+MCP23017	KEYWORD1
+MCP23017_Port_t	KEYWORD1
+MCP23017_Register_t	KEYWORD1
+MCP23017_RegisterGeneric_t	KEYWORD1
+MCP23017_Port_t	KEYWORD1
 
 
-pinMode	 KEYWORD2
-digitalWrit KEYWORD2
-digitalRead KEYWORD2
-portMode KEYWORD2
-writePort KEYWORD2
-readPort KEYWORD2
-chipMode KEYWORD2
-writeChip KEYWORD2
-readChip KEYWORD2
-setInputPolarity KEYWORD2
-getInterrupt KEYWORD2
+pinMode	KEYWORD2
+digitalWrit	KEYWORD2
+digitalRead	KEYWORD2
+portMode	KEYWORD2
+writePort	KEYWORD2
+readPort	KEYWORD2
+chipMode	KEYWORD2
+writeChip	KEYWORD2
+readChip	KEYWORD2
+setInputPolarity	KEYWORD2
+getInterrupt	KEYWORD2
 getInterruptCapture	KEYWORD2
-setInterrupt KEYWORD2
-interruptMirror KEYWORD2
-setIntPinMode KEYWORD2
+setInterrupt	KEYWORD2
+interruptMirror	KEYWORD2
+setIntPinMode	KEYWORD2
 
-PORT_A LITERAL1
-PORT_B LITERAL1
+PORT_A	LITERAL1
+PORT_B	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords